### PR TITLE
Add French API key error constant

### DIFF
--- a/src/constants/error_messages.py
+++ b/src/constants/error_messages.py
@@ -21,6 +21,7 @@ ERROR_ORDER_PRICE_INVALID_NUMBER = "Erreur: Prix invalide. Entrez un nombre." # 
 
 # From app_logic.ApiKeyMissingError (message is already part of the exception)
 # API_KEY_SECRET_REQUIRED = "API Key and Secret Key are required." # Defined in app_logic.py
+PARAM_API_KEYS_REQUIRED = "API Key et Secret Key sont requis."
 
 # From app_logic.InvalidOrderParamsError (some are specific in exception, these are from validation)
 PARAM_SYMBOL_REQUIRED = "Le symbole est requis."


### PR DESCRIPTION
## Summary
- define `PARAM_API_KEYS_REQUIRED` in error messages

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement ccxt)*
- `pytest -q` *(fails to collect tests: ModuleNotFoundError for ccxt and src)*

------
https://chatgpt.com/codex/tasks/task_e_684a0bd24b5c8333a4109cbfd6794666