### PR TITLE
Fix keyring logging

### DIFF
--- a/src/main_pyqt.py
+++ b/src/main_pyqt.py
@@ -1,5 +1,6 @@
 import sys
 import time # Required for BatchDcaOrderWorker
+import logging
 from PyQt5.QtWidgets import QApplication, QMainWindow, QStatusBar
 from PyQt5.QtCore import QThread, pyqtSignal, pyqtSlot
 
@@ -144,7 +145,7 @@ class BinanceAppPyQt(QMainWindow):
             self.ui.saveApiKeysCheckBox.setEnabled(False)
             self.ui.saveApiKeysCheckBox.setToolTip(ui_strings.LABEL_KEYRING_UNAVAILABLE)
             self.statusBar().showMessage(ui_strings.LABEL_KEYRING_UNAVAILABLE, 5000)
-            print(ui_strings.LABEL_KEYRING_UNAVAILABLE)
+            logging.warning(ui_strings.LABEL_KEYRING_UNAVAILABLE)
 
         # Connect signals for Balance Tab
         self.ui.fetchBalanceButton.clicked.connect(self.start_fetch_balance)


### PR DESCRIPTION
## Summary
- log keyring unavailability using `logging.warning`
- add logging import for main_pyqt

## Testing
- `python -m unittest discover -s tests -v` *(fails: ModuleNotFoundError: No module named 'ccxt')*

------
https://chatgpt.com/codex/tasks/task_e_684a0f575d148333926a8a334636182f